### PR TITLE
Add fear messages and flicker effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Czy jesteś pewien, że chcesz poznać wynik?
 - Zaskakujące zakończenie (czy na pewno to już koniec?)
 - Całość działa lokalnie, zero zewnętrznych API
 - Krwawe efekty i mroczny motyw wizualny
+- Losowe komunikaty strachu i migotanie ekranu
+- Efekt maszyny do pisania dla pytań
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
         <button id="next" disabled>Dalej</button>
     </div>
     <div id="blood-overlay"></div>
+    <div id="fear-message" class="hidden"></div>
+    <audio id="background-audio" loop></audio>
     <audio id="glitch-audio"></audio>
     <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -85,3 +85,23 @@ button:hover {
 .hidden {
     display: none;
 }
+#fear-message {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 2.5rem;
+    color: #ff0000;
+    text-shadow: 0 0 10px #ff0000;
+    pointer-events: none;
+    z-index: 101;
+}
+
+.flicker {
+    animation: flicker 0.1s infinite;
+}
+
+@keyframes flicker {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}


### PR DESCRIPTION
## Summary
- add fear message container and background audio elements
- implement typed text, fear messages and background hum
- add flicker styling and fear message overlay
- document new creepy features

## Testing
- `node -e "console.log('test node')"`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68535b1a81d4832ea8808b628175d96a